### PR TITLE
チャット画面自動更新 1

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -91,7 +91,7 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log('error');
+      alert("メッセージ送信に失敗しました");
     });
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
 $(function(){
+  
   function buildHTML(message){
-    if ( message.image ) {
-      var html =
-       `<div class="message" data-message-id=${message.id}>
+    if ( message.content && message.image ) {
+      var html = `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -15,13 +15,11 @@ $(function(){
             <p class="lower-message__content">
               ${message.content}
             </p>
-          </div>
-          <img src=${message.image} >
+          </div >
+            <img src=${message.image} >
         </div>`
-      return html;
-    } else {
-      var html =
-       `<div class="message" data-message-id=${message.id}>
+    } else if (message.content) {
+      var html = `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -36,13 +34,25 @@ $(function(){
             </p>
           </div>
         </div>`
-      return html;
+    } else if (message.image) {
+      var html = `<div class="message" data-message-id=${message.id}>
+          <div class="upper-message">
+            <div class="upper-message__user-name">
+              ${message.user_name}
+            </div>
+            <div class="upper-message__date">
+              ${message.created_at}
+            </div>
+          </div>
+            <img src=${message.image} >
+        </div>`
     };
-  }
+    return html;
+  };
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
-    var url = $(this).attr('action');
+    var url = $(this).attr('action')
     $.ajax({
       url: url,
       type: "POST",
@@ -51,15 +61,40 @@ $(function(){
       processData: false,
       contentType: false
     })
-    .done(function(data){
+    .done(function(data){ 
       var html = buildHTML(data);
       $('.main-message').append(html);
-      $('.form__submit').attr('disabled', false);
-      $('.main-message').animate({ scrollTop: $('.main-message')[0].scrollHeight});
-      $('form')[0].reset();
+      $("form")[0].reset();
+      $('input').prop('disabled', false);
+      $('.main-message').animate({scrollTop: $('.main-message')[0].scrollHeight}, 10);
     })
     .fail(function() {
-      alert('メッセージを送信できません');
+      alert("メッセージ送信に失敗しました");
     });
   });
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main-message').append(insertHTML);
+        $('.main-message').animate({ scrollTop: $('.main-message')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,8 +10,9 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-        format.json
-      end
+      format.html { redirect_to group_messages_path(@group) }
+      format.json
+    end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content    message.content
+  json.image      message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name  message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
 json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
・カスタムデータ属性の取得
・namespaceを利用したコントローラーのルーティング設定
・jBuilderの設定
・$('.message:last')の使用
・setInterval()関数の導入
・animate関数の導入
・matchメソッドの利用

# Why
・表示されているメッセージのidが確認
・新規投稿の取得
・投稿内容のレスポンス
・取得した投稿データの表示
・数秒ごとにリクエストする
・メッセージを取得したら画面がスクロール
・自動更新が必要ない画面では行わない

https://gyazo.com/035c1622be2b34e34cc6d32524908e0f